### PR TITLE
Substring decryption

### DIFF
--- a/box.go
+++ b/box.go
@@ -11,8 +11,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 // Converts a byte slice to the [32]byte expected by NaCL
@@ -147,15 +147,9 @@ func genkey(publicKeyFile string, privateKeyFile string) {
 	pemWrite(privateKey, privateKeyFile, "NACL PRIVATE KEY", 0600)
 }
 
-func extractEnvelopes(payload string) (envelopes []string, err error) {
+func extractEnvelopes(payload string) []string {
 	re := regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=]+\\]")
-
-	res := re.FindAllString(payload, 2)
-	if len(res) == 0 {
-		return nil, errors.New("Couldn't find any envelopes in payload: " + payload)
-	}
-	
-	return res, nil
+	return re.FindAllString(payload, 2)
 }
 
 func isEnvelope(envelope string) bool {

--- a/box.go
+++ b/box.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"regexp"
 )
 
 // Converts a byte slice to the [32]byte expected by NaCL
@@ -144,6 +145,17 @@ func genkey(publicKeyFile string, privateKeyFile string) {
 
 	pemWrite(publicKey, publicKeyFile, "NACL PUBLIC KEY", 0644)
 	pemWrite(privateKey, privateKeyFile, "NACL PRIVATE KEY", 0600)
+}
+
+func extractEnvelopes(payload string) (envelopes []string, err error) {
+	re := regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=]+\\]")
+
+	res := re.FindAllString(payload, 2)
+	if len(res) == 0 {
+		return nil, errors.New("Couldn't find any envelopes in payload: " + payload)
+	}
+	
+	return res, nil
 }
 
 func isEnvelope(envelope string) bool {

--- a/box_test.go
+++ b/box_test.go
@@ -46,6 +46,33 @@ func TestFindKey(t *testing.T) {
 	assert.Nil(t, findKey("", "RANDOM_ENVVAR_THAT_DOESNT_EXIST", "./resources/test/keys/nonexist-public-key.pem"))
 }
 
+func TestExtractEnvelopes(t *testing.T) {
+	envelopes, err := extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(envelopes))
+	assert.Equal(t, []string{"ENC[NACL,uSr123+/=]", "ENC[NACL,pWd123+/=]"}, envelopes)
+	
+	envelopes, err = extractEnvelopes("amqp://ENC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(envelopes))
+	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
+	
+	envelopes, err = extractEnvelopes("amqp://ENC[NACL,:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(envelopes))
+	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
+	
+	envelopes, err = extractEnvelopes("amqp://NC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(envelopes))
+	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
+	
+	envelopes, err = extractEnvelopes("amqp://ENC[NACL,abc:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(envelopes))
+	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
+}
+
 func TestIsEnvelope(t *testing.T) {
 	assert.True(t, isEnvelope("ENC[NACL,]"))
 	assert.True(t, isEnvelope("ENC[NACL,abc]"))

--- a/box_test.go
+++ b/box_test.go
@@ -47,28 +47,23 @@ func TestFindKey(t *testing.T) {
 }
 
 func TestExtractEnvelopes(t *testing.T) {
-	envelopes, err := extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
-	assert.Nil(t, err)
+	envelopes := extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
 	assert.Equal(t, 2, len(envelopes))
 	assert.Equal(t, []string{"ENC[NACL,uSr123+/=]", "ENC[NACL,pWd123+/=]"}, envelopes)
-	
-	envelopes, err = extractEnvelopes("amqp://ENC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
-	assert.Nil(t, err)
+
+	envelopes = extractEnvelopes("amqp://ENC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
 	assert.Equal(t, 1, len(envelopes))
 	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
-	
-	envelopes, err = extractEnvelopes("amqp://ENC[NACL,:ENC[NACL,pWd123+/=]@rabbit:5672/")
-	assert.Nil(t, err)
+
+	envelopes = extractEnvelopes("amqp://ENC[NACL,:ENC[NACL,pWd123+/=]@rabbit:5672/")
 	assert.Equal(t, 1, len(envelopes))
 	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
-	
-	envelopes, err = extractEnvelopes("amqp://NC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
-	assert.Nil(t, err)
+
+	envelopes = extractEnvelopes("amqp://NC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
 	assert.Equal(t, 1, len(envelopes))
 	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
-	
-	envelopes, err = extractEnvelopes("amqp://ENC[NACL,abc:ENC[NACL,pWd123+/=]@rabbit:5672/")
-	assert.Nil(t, err)
+
+	envelopes = extractEnvelopes("amqp://ENC[NACL,abc:ENC[NACL,pWd123+/=]@rabbit:5672/")
 	assert.Equal(t, 1, len(envelopes))
 	assert.Equal(t, []string{"ENC[NACL,pWd123+/=]"}, envelopes)
 }

--- a/commands.go
+++ b/commands.go
@@ -33,16 +33,14 @@ func decryptStream(input io.Reader, output io.Writer, crypto Crypto) {
 	envelope, err := ioutil.ReadAll(input)
 	check(err, "Failed to read encrypted data from standard input")
 
-	mangled := stripWhitespace(string(envelope))
-	result := mangled
-	
-	envelopes, err := extractEnvelopes(mangled)
-		
-	if err == nil && len(envelopes) > 0 {	
+	result := stripWhitespace(string(envelope))
+	envelopes := extractEnvelopes(result)
+
+	if len(envelopes) > 0 {
 		for _, envelope := range envelopes {
 			plaintext, err := crypto.Decrypt(envelope)
 			check(err)
-			
+
 			result = strings.Replace(result, envelope, string(plaintext), 1)
 		}
 	}
@@ -57,12 +55,11 @@ func decryptEnvironment(input []string, output io.Writer, crypto Crypto) {
 	for _, item := range input {
 		keyval := strings.SplitN(item, "=", 2)
 		key, value := keyval[0], keyval[1]
-		mangled := stripWhitespace(value)
-		result := mangled
-		
-		envelopes, err := extractEnvelopes(mangled)
-		
-		if err == nil && len(envelopes) > 0 {	
+
+		result := stripWhitespace(value)
+		envelopes := extractEnvelopes(result)
+
+		if len(envelopes) > 0 {
 			for _, envelope := range envelopes {
 				plaintext, err := crypto.Decrypt(envelope)
 				if err != nil {
@@ -70,9 +67,10 @@ func decryptEnvironment(input []string, output io.Writer, crypto Crypto) {
 					haserr = true
 					continue
 				}
-				
+
 				result = strings.Replace(result, envelope, string(plaintext), 1)
 			}
+
 			fmt.Fprintf(output, "export %s='%s'\n", key, result)
 		}
 	}

--- a/commands_test.go
+++ b/commands_test.go
@@ -24,6 +24,26 @@ func TestEncryptDecryptCommand(t *testing.T) {
 	assert.Equal(t, "secret", output.String())
 }
 
+func TestEncryptDecryptCommandSubstrings(t *testing.T) {
+	input := bytes.NewBufferString("secret")
+	input2 := bytes.NewBufferString("secret2")
+	var encrypted, output bytes.Buffer
+
+	configPublicKey := pemRead("./resources/test/keys/config-public-key.pem")
+	configPrivateKey := pemRead("./resources/test/keys/config-private-key.pem")
+	masterPublicKey := pemRead("./resources/test/keys/master-public-key.pem")
+	masterPrivateKey := pemRead("./resources/test/keys/master-private-key.pem")
+
+	encryptCommand(input, &encrypted, masterPublicKey, configPrivateKey, false)
+	encrypted.Write([]byte("somepadding"))
+	encryptCommand(input2, &encrypted, masterPublicKey, configPrivateKey, false)
+
+	crypto := newKeyCrypto(configPublicKey, masterPrivateKey)
+	decryptStream(&encrypted, &output, crypto)
+
+	assert.Equal(t, "secretsomepaddingsecret2", output.String())
+}
+
 func TestDecryptEnvironmentCommand(t *testing.T) {
 	var output bytes.Buffer
 
@@ -44,4 +64,26 @@ func TestDecryptEnvironmentCommand(t *testing.T) {
 	decryptEnvironment(input, &output, crypto)
 
 	assert.Equal(t, "export b='secret'\nexport e='secret2'\n", output.String())
+}
+
+func TestDecryptEnvironmentCommandSubstrings(t *testing.T) {
+	var output bytes.Buffer
+
+	configPublicKey := pemRead("./resources/test/keys/config-public-key.pem")
+	configPrivateKey := pemRead("./resources/test/keys/config-private-key.pem")
+	masterPublicKey := pemRead("./resources/test/keys/master-public-key.pem")
+	masterPrivateKey := pemRead("./resources/test/keys/master-private-key.pem")
+
+	encrypted, err := encryptEnvelope(masterPublicKey, configPrivateKey, []byte("secret"))
+	assert.Nil(t, err)
+
+	encrypted2, err := encryptEnvelope(masterPublicKey, configPrivateKey, []byte("secret2"))
+	assert.Nil(t, err)
+
+	input := []string{"a=b", fmt.Sprintf("b=blabla%sblabla%s", encrypted, encrypted2), "c=d"}
+
+	crypto := newKeyCrypto(configPublicKey, masterPrivateKey)
+	decryptEnvironment(input, &output, crypto)
+
+	assert.Equal(t, "export b='blablasecretblablasecret2'\n", output.String())
 }


### PR DESCRIPTION
Implements support for substring decryption.

For example, sending in `amqp://ENC[NACL,encrypted_usr]:ENC[NACL,encrypted_pwd]@rabbit:5672/` will resolve both encrypted strings and replace them.