### PR TITLE
Only strip whitespace inside envelopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 	 ln -sf "secretary-`uname -s`-`uname -m`" secretary
 
 test:
-	go test -v -coverprofile=coverage.txt -covermode=atomic
+	go test -bench=. -v -coverprofile=coverage.txt -covermode=atomic
 
 clean:
 	rm -f ./secretary

--- a/box.go
+++ b/box.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 )
 
+var envelopeRegexp = regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=]+\\]")
+
 // Converts a byte slice to the [32]byte expected by NaCL
 func asKey(data []byte) (*[32]byte, error) {
 	if len(data) != 32 {
@@ -148,8 +150,7 @@ func genkey(publicKeyFile string, privateKeyFile string) {
 }
 
 func extractEnvelopes(payload string) []string {
-	re := regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=]+\\]")
-	return re.FindAllString(payload, 2)
+	return envelopeRegexp.FindAllString(payload, 2)
 }
 
 func isEnvelope(envelope string) bool {

--- a/box.go
+++ b/box.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var envelopeRegexp = regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=]+\\]")
+var envelopeRegexp = regexp.MustCompile("ENC\\[NACL,[a-zA-Z0-9+/=\\s]+\\]")
 
 // Converts a byte slice to the [32]byte expected by NaCL
 func asKey(data []byte) (*[32]byte, error) {

--- a/box_test.go
+++ b/box_test.go
@@ -125,3 +125,9 @@ func TestEncryptEnvelope(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "secret", string(plaintext), "Should decrypt plaintext")
 }
+
+func BenchmarkExtractEnvelopes(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+    	extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
+    }
+}

--- a/box_test.go
+++ b/box_test.go
@@ -128,6 +128,6 @@ func TestEncryptEnvelope(t *testing.T) {
 
 func BenchmarkExtractEnvelopes(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-    	extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
-    }
+		extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/")
+	}
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -87,3 +87,25 @@ func TestDecryptEnvironmentCommandSubstrings(t *testing.T) {
 
 	assert.Equal(t, "export b='blablasecretblablasecret2'\n", output.String())
 }
+
+func TestDecryptEnvironmentCommandSubstringsSpaces(t *testing.T) {
+	var output bytes.Buffer
+
+	configPublicKey := pemRead("./resources/test/keys/config-public-key.pem")
+	configPrivateKey := pemRead("./resources/test/keys/config-private-key.pem")
+	masterPublicKey := pemRead("./resources/test/keys/master-public-key.pem")
+	masterPrivateKey := pemRead("./resources/test/keys/master-private-key.pem")
+
+	encrypted, err := encryptEnvelope(masterPublicKey, configPrivateKey, []byte("secret"))
+	assert.Nil(t, err)
+
+	encrypted2, err := encryptEnvelope(masterPublicKey, configPrivateKey, []byte("secret2"))
+	assert.Nil(t, err)
+
+	input := []string{"a=b", fmt.Sprintf("b=blabla %sb la bla %s", encrypted, encrypted2), "c=d"}
+
+	crypto := newKeyCrypto(configPublicKey, masterPrivateKey)
+	decryptEnvironment(input, &output, crypto)
+
+	assert.Equal(t, "export b='blabla secretb la bla secret2'\n", output.String())
+}


### PR DESCRIPTION
Right now we strip whitespace from the whole incoming payload. This can be destructive when substring secrets is used. This change will only strip whitespace inside the envelopes.