### PR TITLE
Add support for substring encryption to the authorization verification

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 )
 
 // DaemonRequest TODO
@@ -59,7 +60,7 @@ func decryptRequest(app *MarathonApp, masterKey *[32]byte, serviceEnvelope strin
 func verifyAuthorization(app *MarathonApp, request *DaemonRequest) (bool, error) {
 	// Verify that encrypted string is present in app config
 	for _, value := range app.Env {
-		if stripWhitespace(value) == request.RequestedSecret {
+		if strings.Contains(stripWhitespace(value), request.RequestedSecret) {
 			return true, nil
 		}
 	}

--- a/resources/test/marathon-apps-encsubstr.json
+++ b/resources/test/marathon-apps-encsubstr.json
@@ -1,0 +1,153 @@
+{
+  "app": {
+    "id": "/demo/webapp3",
+    "cmd": null,
+    "args": null,
+    "user": null,
+    "env": {
+      "MASTER_PUBLIC_KEY": "4qWrxezV1LMehxHyWg1JOZ6KIoZ8LSdVGZQ4ehuAYy4=",
+      "DEPLOY_PRIVATE_KEY": "8Cw5ysGd14dRObahAX/MtPrkmc7tOVj6OX5lM8HxerI=",
+      "SECRETARY_URL": "http://localhost:5070",
+      "DEPLOY_PUBLIC_KEY": "omO6DSEw/mZDG9NuhyEC4uYbgwwqEivOuX0EqX9+Ql0=",
+      "DATABASE_PASSWORD": "amqp://guest:ENC[NACL,jpDAHM6WZe/1C93FLHd2M916U9AQwjT3VdvzQ7JHTHc57dLXsGE+oI8wDE2Fiw==]@kappa:1337",
+      "SERVICE_PUBLIC_KEY": "kVOhhw2wAJuAofxO7h4EM0xboxGAwnsq9J6fluFY5CQ=",
+      "DATABASE": "mysql://$HOST:3306",
+      "DATABASE_USERNAME": "myuser",
+      "SSH_KEY": " ENC[NACL,egFSuFDkZxsmv9w7bWyZyxCBQQeykctG2H6UTiK7EHRdQI3E3NsZBP8 \n 4Gqy8c5kh8BYErki6F0eqKAxd3u/QcOuMD17YgqTGiE/PMlO75yCuBzCnZNW7Y4b\n5Ww03v6uo1Fr/ew==] "
+    },
+    "instances": 3,
+    "cpus": 0.1,
+    "mem": 200.0,
+    "disk": 0.0,
+    "executor": "",
+    "constraints": [
+      [
+        "hostname",
+        "GROUP_BY"
+      ]
+    ],
+    "uris": [],
+    "storeUrls": [],
+    "ports": [
+      1234
+    ],
+    "requirePorts": false,
+    "backoffSeconds": 1,
+    "backoffFactor": 1.15,
+    "maxLaunchDelaySeconds": 3600,
+    "container": {
+      "type": "DOCKER",
+      "volumes": [
+        {
+          "containerPath": "/usr/bin/secretary",
+          "hostPath": "/home/mikl/src/secretary/secretary-Linux-x86_64",
+          "mode": "RO"
+        }
+      ],
+      "docker": {
+        "image": "meltwater/mesos-demo-webapp:latest",
+        "network": "HOST",
+        "privileged": false,
+        "parameters": [],
+        "forcePullImage": false
+      }
+    },
+    "healthChecks": [
+      {
+        "path": "/_status",
+        "protocol": "HTTP",
+        "portIndex": 0,
+        "gracePeriodSeconds": 15,
+        "intervalSeconds": 10,
+        "timeoutSeconds": 5,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
+      }
+    ],
+    "dependencies": [],
+    "upgradeStrategy": {
+      "minimumHealthCapacity": 1.0,
+      "maximumOverCapacity": 1.0
+    },
+    "labels": {},
+    "acceptedResourceRoles": null,
+    "version": "2015-12-04T12:25:08.426Z",
+    "versionInfo": {
+      "lastScalingAt": "2015-12-04T12:25:08.426Z",
+      "lastConfigChangeAt": "2015-12-04T12:25:08.426Z"
+    },
+    "tasksStaged": 0,
+    "tasksRunning": 3,
+    "tasksHealthy": 3,
+    "tasksUnhealthy": 0,
+    "deployments": [],
+    "tasks": [
+      {
+        "id": "demo_webapp.0f826da3-9a82-11e5-94c7-6a515f434e2d",
+        "host": "192.168.0.194",
+        "ports": [
+          31190
+        ],
+        "startedAt": "2015-12-04T12:25:13.453Z",
+        "stagedAt": "2015-12-04T12:25:10.131Z",
+        "version": "2015-12-04T12:25:08.426Z",
+        "slaveId": "20151204-122450-16842879-5050-1-S0",
+        "appId": "/demo/webapp",
+        "healthCheckResults": [
+          {
+            "alive": true,
+            "consecutiveFailures": 0,
+            "firstSuccess": "2015-12-04T12:25:18.745Z",
+            "lastFailure": null,
+            "lastSuccess": "2015-12-04T12:45:30.450Z",
+            "taskId": "demo_webapp.0f826da3-9a82-11e5-94c7-6a515f434e2d"
+          }
+        ]
+      },
+      {
+        "id": "demo_webapp.0f810e10-9a82-11e5-94c7-6a515f434e2d",
+        "host": "192.168.0.194",
+        "ports": [
+          31506
+        ],
+        "startedAt": "2015-12-04T12:25:13.044Z",
+        "stagedAt": "2015-12-04T12:25:10.122Z",
+        "version": "2015-12-04T12:25:08.426Z",
+        "slaveId": "20151204-122450-16842879-5050-1-S0",
+        "appId": "/demo/webapp",
+        "healthCheckResults": [
+          {
+            "alive": true,
+            "consecutiveFailures": 0,
+            "firstSuccess": "2015-12-04T12:25:18.746Z",
+            "lastFailure": null,
+            "lastSuccess": "2015-12-04T12:45:30.453Z",
+            "taskId": "demo_webapp.0f810e10-9a82-11e5-94c7-6a515f434e2d"
+          }
+        ]
+      },
+      {
+        "id": "demo_webapp.0f844265-9a82-11e5-94c7-6a515f434e2d",
+        "host": "192.168.0.194",
+        "ports": [
+          31656
+        ],
+        "startedAt": "2015-12-04T12:25:12.121Z",
+        "stagedAt": "2015-12-04T12:25:10.142Z",
+        "version": "2015-11-04T12:25:08.426Z",
+        "slaveId": "20151204-122450-16842879-5050-1-S0",
+        "appId": "/demo/webapp",
+        "healthCheckResults": [
+          {
+            "alive": true,
+            "consecutiveFailures": 0,
+            "firstSuccess": "2015-12-04T12:25:18.744Z",
+            "lastFailure": null,
+            "lastSuccess": "2015-12-04T12:45:30.448Z",
+            "taskId": "demo_webapp.0f844265-9a82-11e5-94c7-6a515f434e2d"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/resources/test/marathon-versions-encsubstr.json
+++ b/resources/test/marathon-versions-encsubstr.json
@@ -1,0 +1,78 @@
+{
+  "id": "/demo/webapp3",
+  "cmd": null,
+  "args": null,
+  "user": null,
+  "env": {
+    "MASTER_PUBLIC_KEY": "4qWrxezV1LMehxHyWg1JOZ6KIoZ8LSdVGZQ4ehuAYy4=",
+    "DEPLOY_PRIVATE_KEY": "8Cw5ysGd14dRObahAX/MtPrkmc7tOVj6OX5lM8HxerI=",
+    "SECRETARY_URL": "http://localhost:5070",
+    "DEPLOY_PUBLIC_KEY": "omO6DSEw/mZDG9NuhyEC4uYbgwwqEivOuX0EqX9+Ql0=",
+    "DATABASE_PASSWORD": "amqp://guest:ENC[NACL,jpDAHM6WZe/1C93FLHd2M916U9AQwjT3VdvzQ7JHTHc57dLXsGE+oI8wDE2Fiw==]@kappa:1337",
+    "SERVICE_PUBLIC_KEY": "kVOhhw2wAJuAofxO7h4EM0xboxGAwnsq9J6fluFY5CQ=",
+    "DATABASE": "mysql://$HOST:3306",
+    "DATABASE_USERNAME": "myuser",
+    "SSH_KEY": " ENC[NACL,egFSuFDkZxsmv9w7bWyZyxCBQQeykctG2H6UTiK7EHRdQI3E3NsZBP8 \n 4Gqy8c5kh8BYErki6F0eqKAxd3u/QcOuMD17YgqTGiE/PMlO75yCuBzCnZNW7Y4b\n5Ww03v6uo1Fr/ew==] "
+  },
+  "instances": 3,
+  "cpus": 0.1,
+  "mem": 200.0,
+  "disk": 0.0,
+  "executor": "",
+  "constraints": [
+    [
+      "hostname",
+      "GROUP_BY"
+    ]
+  ],
+  "uris": [],
+  "storeUrls": [],
+  "ports": [
+    1234
+  ],
+  "requirePorts": false,
+  "backoffSeconds": 1,
+  "backoffFactor": 1.15,
+  "maxLaunchDelaySeconds": 3600,
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "/usr/bin/secretary",
+        "hostPath": "/home/mikl/src/secretary/secretary-Linux-x86_64",
+        "mode": "RO"
+      }
+    ],
+    "docker": {
+      "image": "meltwater/mesos-demo-webapp:latest",
+      "network": "HOST",
+      "privileged": false,
+      "parameters": [],
+      "forcePullImage": false
+    }
+  },
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 15,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1.0,
+    "maximumOverCapacity": 1.0
+  },
+  "labels": {},
+  "acceptedResourceRoles": null,
+  "version": "2015-12-04T12:25:08.426Z",
+  "versionInfo": {
+    "lastScalingAt": "2015-12-04T12:25:08.426Z",
+    "lastConfigChangeAt": "2015-12-04T12:25:08.426Z"
+  }
+}


### PR DESCRIPTION
Secretary verifies that the secret requested to be decrypted actually exists
in the marathon app configuration. This commit adds support for verifying
secrets that are a substring to the full value in the configuration. It
also adds a test case for the encrypted substring scenario.