### PR TITLE
Check that envvars are valid identifiers when using encrypted strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,12 @@ func main() {
 				}
 
 				if decryptEnv {
-					decryptEnvironment(os.Environ(), os.Stdout, crypto)
+					// err is also printed on stderr, so no need to use it here
+					ok, _ := decryptEnvironment(os.Environ(), os.Stdout, crypto)
+
+					if !ok {
+						os.Exit(1)
+					}
 				} else {
 					decryptStream(os.Stdin, os.Stdout, crypto)
 				}


### PR DESCRIPTION
When Secretary decrypts something it outputs a scriptlet that is sourced into the env, to overwrite encrypted env vars with decrypted ones. Meaning that env vars with encrypted substrings like rabbitmq.password won't work since they contain dots. This change ensures the problem is caught with a user readable error