### PR TITLE
update dependencies and compile with go 1.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 go:
-  - 1.6
+  - 1.6.3
 
 # Deploy executables to Github release tags
 deploy:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 53631256b18ad67729c084e889cc48a26ddb71996a9ac51a02dc0f75a715b016
-updated: 2016-07-19T16:42:25.64010548+02:00
+updated: 2016-07-19T16:58:37.496994643+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: bc2c5714d312337494394909e7cc3a19a2e68530
@@ -55,4 +55,12 @@ imports:
   - curve25519
   - salsa20/salsa
   - poly1305
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: e8554b8641db39598be7f6342874b958f12ae1d4
+  subpackages:
+  - difflib

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 53631256b18ad67729c084e889cc48a26ddb71996a9ac51a02dc0f75a715b016
-updated: 2016-02-09T16:09:49.633856828+01:00
+updated: 2016-07-19T16:42:25.64010548+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: bc2c5714d312337494394909e7cc3a19a2e68530
@@ -27,20 +27,14 @@ imports:
   version: 71acacd42f85e5e82f70a55327789582a5200a90
   subpackages:
   - md2man
-- name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
-  subpackages:
-  - spew
 - name: github.com/go-errors/errors
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
 - name: github.com/go-ini/ini
   version: afbd495e5aaea13597b5e14fe514ddeaa4d76fc3
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
   version: fba8638ac545c50f9e6855ed106b62ba9f9f3aea
-- name: github.com/pmezard/go-difflib
-  version: e8554b8641db39598be7f6342874b958f12ae1d4
-  subpackages:
-  - difflib
 - name: github.com/russross/blackfriday
   version: d18b67ae0afd61dae240896eae1785f00709aa31
 - name: github.com/shurcooL/sanitized_anchor_name
@@ -49,14 +43,10 @@ imports:
   version: 73665614cb7fd60a66444c4c9f41a2a4e8a26ad7
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
-- name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
   version: e3a8ff8ce36581f87a15341206f205b1da467059
   subpackages:
   - assert
-  - http
-  - mock
 - name: golang.org/x/crypto
   version: f18420efc3b4f8e9f3d51f6bd2476e92c46260e9
   subpackages:


### PR DESCRIPTION
Updated dependencies with `glide up`, and switch go compiler to 1.6.3 which adds support for macOS Sierra.