### PR TITLE
Avoid need for workarounds for $AWS_DEFAULT_REGION

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,34 @@
-hash: 53631256b18ad67729c084e889cc48a26ddb71996a9ac51a02dc0f75a715b016
-updated: 2016-07-19T16:58:37.496994643+02:00
+hash: 4a06f75a431c0ee528e33e41ff3c928db7749adbc1b7e113c92711cee4132118
+updated: 2016-09-30T18:50:11.699904165+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: bc2c5714d312337494394909e7cc3a19a2e68530
+  version: 74a703abb31ea9faf7622930e5daba1559b01b37
   subpackages:
-  - aws/session
-  - service/kms
   - aws
-  - aws/client
-  - aws/corehandlers
-  - aws/defaults
-  - aws/request
-  - private/endpoints
-  - aws/awsutil
-  - aws/client/metadata
-  - private/protocol
-  - private/protocol/jsonrpc
-  - private/signer/v4
   - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
   - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
   - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
   - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - service/kms
+  - service/sts
 - name: github.com/cpuguy83/go-md2man
   version: 71acacd42f85e5e82f70a55327789582a5200a90
   subpackages:
@@ -50,11 +56,11 @@ imports:
 - name: golang.org/x/crypto
   version: f18420efc3b4f8e9f3d51f6bd2476e92c46260e9
   subpackages:
+  - curve25519
   - nacl/box
   - nacl/secretbox
-  - curve25519
-  - salsa20/salsa
   - poly1305
+  - salsa20/salsa
 testImports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,7 @@ import:
   - nacl/box
   - nacl/secretbox
 - package: github.com/aws/aws-sdk-go
+  version: v1.4.14
   subpackages:
   - aws/session
   - service/kms

--- a/kms.go
+++ b/kms.go
@@ -65,7 +65,13 @@ func (k *KmsClientImpl) Decrypt(data []byte) (*[32]byte, error) {
 }
 
 func newKmsClient() *KmsClientImpl {
-	return &KmsClientImpl{Impl: kms.New(session.New())}
+	// Force enable Shared Config to support $AWS_DEFAULT_REGION
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	check(err, "Failed to initialize AWS session")
+
+	return &KmsClientImpl{Impl: kms.New(sess)}
 }
 
 // KmsEncryptionStrategy implements envelope encryption using Amazon AWS KMS

--- a/kms.go
+++ b/kms.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 
 	"golang.org/x/crypto/nacl/secretbox"
@@ -31,12 +34,66 @@ type KmsClientImpl struct {
 	Impl *kms.KMS
 }
 
+// A function that operates on the KMS service
+type KmsFunction func(*kms.KMS) error
+
+// Executes a function with retry for MissingRegion errors
+func (k *KmsClientImpl) CallWithRetry(f KmsFunction) error {
+	// Lazy initialize the session
+	if k.Impl == nil {
+		// Force enable Shared Config to support $AWS_DEFAULT_REGION
+		sess, err := session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		k.Impl = kms.New(sess)
+	}
+
+	// Invoke the function
+	err := f(k.Impl)
+
+	// Attempt to use EC2 meta-data service in case of MissingRegion error
+	if err == aws.ErrMissingRegion {
+		body, err := httpGet("http://169.254.169.254/2016-06-30/dynamic/instance-identity/document")
+		if err == nil {
+			var doc ec2metadata.EC2InstanceIdentityDocument
+			err := json.Unmarshal(body, &doc)
+
+			if err == nil {
+				sess, err := session.NewSessionWithOptions(session.Options{
+					Config: aws.Config{Region: aws.String(doc.Region)},
+					SharedConfigState: session.SharedConfigEnable,
+				})
+
+				if err == nil {
+					k.Impl = kms.New(sess)
+
+					// Retry the function with the new session
+					return f(k.Impl)
+				}
+			}
+		}
+	}
+
+	return err
+}
+
 // GenerateDataKey returns a new symmetric key and its encrypted form
 func (k *KmsClientImpl) GenerateDataKey(keyID string) (*[32]byte, []byte, error) {
+	var response *kms.GenerateDataKeyOutput
 	bytes := int64(32)
-	response, err := k.Impl.GenerateDataKey(&kms.GenerateDataKeyInput{
-		KeyId:         &keyID,
-		NumberOfBytes: &bytes,
+
+	err := k.CallWithRetry(func(impl *kms.KMS) error {
+		var ferr error
+		response, ferr = impl.GenerateDataKey(&kms.GenerateDataKeyInput{
+			KeyId:         &keyID,
+			NumberOfBytes: &bytes,
+		})
+		return ferr
 	})
 
 	if err != nil {
@@ -53,8 +110,14 @@ func (k *KmsClientImpl) GenerateDataKey(keyID string) (*[32]byte, []byte, error)
 
 // Decrypt a symmetric key
 func (k *KmsClientImpl) Decrypt(data []byte) (*[32]byte, error) {
-	response, err := k.Impl.Decrypt(&kms.DecryptInput{
-		CiphertextBlob: data,
+	var response *kms.DecryptOutput
+
+	err := k.CallWithRetry(func(impl *kms.KMS) error {
+		var ferr error
+		response, ferr = impl.Decrypt(&kms.DecryptInput{
+			CiphertextBlob: data,
+		})
+		return ferr
 	})
 
 	if err != nil {
@@ -65,13 +128,7 @@ func (k *KmsClientImpl) Decrypt(data []byte) (*[32]byte, error) {
 }
 
 func newKmsClient() *KmsClientImpl {
-	// Force enable Shared Config to support $AWS_DEFAULT_REGION
-	sess, err := session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	})
-	check(err, "Failed to initialize AWS session")
-
-	return &KmsClientImpl{Impl: kms.New(sess)}
+	return &KmsClientImpl{}
 }
 
 // KmsEncryptionStrategy implements envelope encryption using Amazon AWS KMS


### PR DESCRIPTION
The `awsudo` and awscli tools sets `$AWS_DEFAULT_REGION` instead of `$AWS_REGION` as the AWS Golang SDK expected. To use secretary together with `awsudo` some workarounds are needed, like running a bash subshell and explicitly overriding `$AWS_REGION`.

* Updated to latest release of AWS golang SDK which supports "Shared Config" (e.g. ~/.aws/config)
* Force enable Shared Config which enables the SDK to read `$AWS_DEFAULT_REGION`
* Use EC2 meta-data service to autodetect current AWS region if needed (only works inside EC2)
