### PR TITLE
Add exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ variables:
 override:
   env:
     SERVICE_PUBLIC_KEY: "%{secretary.service.publickey}"
+    SERVICE_PRIVATE_KEY: /service/keys/service-private-key.pem
   container:
     volumes:
      - containerPath: "/service/keys"
@@ -212,6 +213,7 @@ An runtime config automatically expanded by Lighter might look like
         "DEPLOY_PUBLIC_KEY": "0k+v11LV3SOr+XiFJ/ug0KcPPhwkXnVirmO65nAd1LI=",
         "DEPLOY_PRIVATE_KEY": "rEmz7Rt6tUnlC4TKYeNzePYg+p1ePAw4BAtfJAY4zzs=",
         "SERVICE_PUBLIC_KEY": "/1fbWGMTaR+lLQJnEsmxdfwWybKOpPQpyWB3FpNmOF4=",
+        "SERVICE_PRIVATE_KEY": "/service/keys/service-private-key.pem"
         "DATABASE_USERNAME": "myservice",
         "DATABASE_PASSWORD": "ENC[NACL,SLXf+O9iG48uyojT0Zg30Q8/uRV8DizuDWMWtgL5PmTU54jxp5cTGrYeLpd86rA=]",
         "DATABASE_URL": "jdbc:mysql://hostname:3306/schema"

--- a/box.go
+++ b/box.go
@@ -150,6 +150,29 @@ func genkey(publicKeyFile string, privateKeyFile string) {
 	pemWrite(privateKey, privateKeyFile, "NACL PRIVATE KEY", 0600)
 }
 
+func decryptEnvelopes(input string, decryptor DecryptionStrategy) (output string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				err = fmt.Errorf("%v", r)
+			}
+		}
+	}()
+
+	repl := func(envelope string) string {
+		bytes, err := decryptor.Decrypt(envelope)
+		if err != nil {
+			panic(err)
+		}
+		return string(bytes)
+	}
+
+	output = envelopeRegexp.ReplaceAllStringFunc(input, repl)
+	return
+}
+
 func extractEnvelopes(payload string) []string {
 	return envelopeRegexp.FindAllString(payload, -1)
 }

--- a/box.go
+++ b/box.go
@@ -173,10 +173,6 @@ func decryptEnvelopes(input string, decryptor DecryptionStrategy) (output string
 	return
 }
 
-func extractEnvelopes(payload string) []string {
-	return envelopeRegexp.FindAllString(payload, -1)
-}
-
 func extractEnvelopeType(envelope string) string {
 	submatches := envelopeRegexp.FindStringSubmatch(envelope)
 	if submatches != nil {

--- a/box.go
+++ b/box.go
@@ -86,13 +86,21 @@ func findKey(locations ...string) *[32]byte {
 			continue
 		}
 
-		encoded := os.Getenv(location)
-		if encoded != "" {
-			key, err := pemDecode(encoded)
+		// First try to interpret the argument as an environment variable
+		env := os.Getenv(location)
+		if env != "" {
+			// If the environment variable is the path to an existing file, use that
+			if _, err := os.Stat(env); err == nil {
+				return pemRead(env)
+			}
+
+			// Otherwise, try to decode the key as a pem-formatted string
+			key, err := pemDecode(env)
 			check(err, "Failed to decode key in $%s", location)
 			return key
 		}
 
+		// If there is no such environment variable, check whether it is a path to a file
 		if _, err := os.Stat(location); err == nil {
 			return pemRead(location)
 		}

--- a/box.go
+++ b/box.go
@@ -150,7 +150,7 @@ func genkey(publicKeyFile string, privateKeyFile string) {
 	pemWrite(privateKey, privateKeyFile, "NACL PRIVATE KEY", 0600)
 }
 
-func decryptEnvelopes(input string, decryptor DecryptionStrategy) (output string, err error) {
+func decryptEnvelopes(input string, crypto DecryptionStrategy) (output string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var ok bool
@@ -162,7 +162,7 @@ func decryptEnvelopes(input string, decryptor DecryptionStrategy) (output string
 	}()
 
 	repl := func(envelope string) string {
-		bytes, err := decryptor.Decrypt(envelope)
+		bytes, err := crypto.Decrypt(envelope)
 		if err != nil {
 			panic(err)
 		}

--- a/box.go
+++ b/box.go
@@ -162,7 +162,7 @@ func decryptEnvelopes(input string, crypto DecryptionStrategy) (output string, e
 	}()
 
 	repl := func(envelope string) string {
-		bytes, err := crypto.Decrypt(envelope)
+		bytes, err := crypto.Decrypt(stripWhitespace(envelope))
 		if err != nil {
 			panic(err)
 		}

--- a/box_test.go
+++ b/box_test.go
@@ -136,3 +136,22 @@ func TestDecryptEnvelopes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "This is a secret message", result)
 }
+
+func TestDecryptEnvelopesStripsWhitespace(t *testing.T) {
+	privkey, err := pemDecode(privateKey)
+	assert.Nil(t, err)
+
+	pubkey, err := pemDecode(publicKey)
+	assert.Nil(t, err)
+
+	crypto := newKeyDecryptionStrategy(pubkey, privkey)
+
+	envelope, err := encryptEnvelope(pubkey, privkey, []byte("secret"))
+
+	// Add some whitespace to the middle of the envelope
+	envelope = envelope[0:len(envelope)/2] + " \t  \n  \t  " + envelope[len(envelope)/2:len(envelope)]
+
+	result, err := decryptEnvelopes("This is a "+envelope+" message", crypto)
+	assert.Nil(t, err, "%v", err)
+	assert.Equal(t, "This is a secret message", result)
+}

--- a/box_test.go
+++ b/box_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/nacl/box"
+	"io/ioutil"
+	"os"
 )
 
 const privateKey = `Q1PuWtB1E7F1sLpvfBGjL+ZuH+fSCOvMDqTyRQE4GTg=`
@@ -45,6 +47,19 @@ func TestFindKey(t *testing.T) {
 	expected := encode(pemRead("./resources/test/keys/config-public-key.pem")[:])
 	assert.Equal(t, expected, encode(findKey("", "RANDOM_ENVVAR_THAT_DOESNT_EXIST", "./resources/test/keys/config-public-key.pem")[:]))
 	assert.Nil(t, findKey("", "RANDOM_ENVVAR_THAT_DOESNT_EXIST", "./resources/test/keys/nonexist-public-key.pem"))
+}
+
+func TestFindKeyEnvironmentPem(t *testing.T) {
+	bytes, _ := ioutil.ReadFile("./resources/test/keys/config-public-key.pem")
+	os.Setenv("PUBLIC_KEY", string(bytes))
+	expected, _ := pemDecode(string(bytes))
+	assert.Equal(t, expected, findKey("PUBLIC_KEY"))
+}
+
+func TestFindKeyEnvironmentPath(t *testing.T) {
+	os.Setenv("PUBLIC_KEY", "./resources/test/keys/config-public-key.pem")
+	expected := pemRead("./resources/test/keys/config-public-key.pem")
+	assert.Equal(t, expected, findKey("PUBLIC_KEY"))
 }
 
 func TestExtractEnvelopeType(t *testing.T) {

--- a/box_test.go
+++ b/box_test.go
@@ -121,3 +121,18 @@ func BenchmarkDecryptEnvelopes(b *testing.B) {
 		decryptEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/", NoopDecryptionStrategy)
 	}
 }
+
+func TestDecryptEnvelopes(t *testing.T) {
+	privkey, err := pemDecode(privateKey)
+	assert.Nil(t, err)
+
+	pubkey, err := pemDecode(publicKey)
+	assert.Nil(t, err)
+
+	envelope, err := encryptEnvelope(pubkey, privkey, []byte("secret"))
+	crypto := newKeyDecryptionStrategy(pubkey, privkey)
+
+	result, err := decryptEnvelopes("This is a "+envelope+" message", crypto)
+	assert.Nil(t, err)
+	assert.Equal(t, "This is a secret message", result)
+}

--- a/box_test.go
+++ b/box_test.go
@@ -116,7 +116,7 @@ func (noopDecryptionStrategyType) Decrypt(envelope string) ([]byte, error) {
 
 var NoopDecryptionStrategy DecryptionStrategy = noopDecryptionStrategyType{}
 
-func BenchmarkExtractEnvelopes(b *testing.B) {
+func BenchmarkDecryptEnvelopes(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		decryptEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/", NoopDecryptionStrategy)
 	}

--- a/commands.go
+++ b/commands.go
@@ -36,18 +36,8 @@ func encryptCommand(input io.Reader, output io.Writer, crypto EncryptionStrategy
 func decryptStream(input io.Reader, output io.Writer, crypto DecryptionStrategy) {
 	payload, err := ioutil.ReadAll(input)
 	check(err, "Failed to read encrypted data from standard input")
-	result := string(payload)
-
-	envelopes := extractEnvelopes(string(payload))
-	if len(envelopes) > 0 {
-		for _, envelope := range envelopes {
-			plaintext, err := crypto.Decrypt(stripWhitespace(envelope))
-			check(err)
-
-			result = strings.Replace(result, envelope, string(plaintext), 1)
-		}
-	}
-
+	result, err := decryptEnvelopes(string(payload), crypto)
+	check(err, "Failed to decrypt from standard input")
 	output.Write([]byte(result))
 }
 
@@ -60,28 +50,20 @@ func decryptEnvironment(input []string, output io.Writer, crypto DecryptionStrat
 		keyval := strings.SplitN(item, "=", 2)
 		key, value := keyval[0], keyval[1]
 		result := value
-
-		envelopes := extractEnvelopes(value)
-		if len(envelopes) > 0 {
+		decryptedResult, suberr := decryptEnvelopes(result, crypto)
+		if suberr != nil {
+			ok = false
+			err = suberr
+			fmt.Fprintf(os.Stderr, "%s: %s\n", key, err)
+			continue
+		}
+		if decryptedResult != result {
 			if !shellIdentifierRegexp.Match([]byte(key)) {
 				ok = false
 				err = fmt.Errorf("the env var '%s' is not a valid shell script identifier. Only alphanumeric characters and underscores are supported, starting with an alphabetic or underscore character", key)
 				fmt.Fprintf(os.Stderr, "%s: %s\n", key, err)
 			}
-
-			for _, envelope := range envelopes {
-				plaintext, suberr := crypto.Decrypt(stripWhitespace(envelope))
-				if suberr != nil {
-					ok = false
-					err = suberr
-					fmt.Fprintf(os.Stderr, "%s: %s\n", key, err)
-					continue
-				}
-
-				result = strings.Replace(result, envelope, string(plaintext), 1)
-			}
-
-			fmt.Fprintf(output, "export %s='%s'\n", key, result)
+			fmt.Fprintf(output, "export %s='%s'\n", key, decryptedResult)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -189,6 +189,9 @@ func main() {
 			},
 		}
 
+		// The usage template is here in order to give the usage text:
+		//     secretary exec [flags] -- cmd [args...]
+		// No immediately obvious way to accomplish that other than replacing the entire usage template.
 		cmdExec.SetUsageTemplate(`Usage:{{if .Runnable}}
   {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}} -- cmd [args...]{{if gt .Aliases 0}}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"syscall"
+
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 )
@@ -135,6 +137,96 @@ func main() {
 
 		cmdDecrypt.Flags().BoolVarP(&decryptEnv, "decrypt-env", "e", false, "Decrypt environment variables")
 		rootCmd.AddCommand(cmdDecrypt)
+	}
+
+	// Exec command
+	{
+		var secretaryURL, appID, appVersion, taskID string
+		var configKeyFile, masterKeyFile, deployKeyFile, serviceKeyFile string
+		cmdExec := &cobra.Command{
+			Use:   "exec",
+			Short: "execute program, decrypting environment variables and arguments",
+			PreRun: func(cmd *cobra.Command, args []string) {
+				if len(args) == 0 {
+					fmt.Print("Error: Must supply at least one command\n\n")
+					cmd.Usage()
+					os.Exit(1)
+				}
+			},
+			Run: func(cmd *cobra.Command, args []string) {
+				var crypto DecryptionStrategy
+
+				if len(secretaryURL) > 0 {
+					deployKey := requireKey("deploy private", deployKeyFile, "DEPLOY_PRIVATE_KEY", "./keys/master-private-key.pem")
+					masterKey := requireKey("master public", masterKeyFile, "MASTER_PUBLIC_KEY", "./keys/master-public-key.pem")
+					serviceKey := findKey(serviceKeyFile, "SERVICE_PRIVATE_KEY")
+					crypto = newDaemonDecryptionStrategy(
+						secretaryURL, appID, appVersion, taskID,
+						masterKey, deployKey, serviceKey)
+				} else {
+					// Send ENC[KMS,..] and ENC[NACL,...] to separate decryptors
+					composite := newCompositeDecryptionStrategy()
+					composite.Add("KMS", newKmsDecryptionStrategy(newKmsClient()))
+
+					deployKey := findKey("deploy private", deployKeyFile, "DEPLOY_PRIVATE_KEY", "./keys/master-private-key.pem")
+					configKey := findKey("config public", configKeyFile, "CONFIG_PUBLIC_KEY", "./keys/config-public-key.pem")
+					if deployKey != nil && configKey != nil {
+						composite.Add("NACL", newKeyDecryptionStrategy(configKey, deployKey))
+					}
+
+					crypto = composite
+				}
+
+				newCmd, newArgs, newEnvs, err := createExecArgs(args, os.Environ(), crypto)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v", err)
+					os.Exit(1)
+				}
+
+				if err := syscall.Exec(newCmd, newArgs, newEnvs); err != nil {
+					fmt.Fprintf(os.Stderr, "Error when executing command \"%s\": %v\n", newCmd, err)
+				}
+			},
+		}
+
+		cmdExec.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
+  {{ .CommandPath}} [command]{{end}} -- cmd [args...]{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasSubCommands }}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
+
+		cmdExec.Flags().StringVarP(&deployKeyFile, "private-key", "", "", "Private key file for use without daemon")
+
+		cmdExec.Flags().StringVarP(&configKeyFile, "config-key", "", "", "Config public key file")
+		cmdExec.Flags().StringVarP(&masterKeyFile, "master-key", "", "", "Master public key file")
+		cmdExec.Flags().StringVarP(&deployKeyFile, "deploy-key", "", "", "Private deploy key file")
+		cmdExec.Flags().StringVarP(&serviceKeyFile, "service-key", "", "", "Private service key file")
+
+		cmdExec.Flags().StringVarP(&secretaryURL, "secretary-url", "s", os.Getenv("SECRETARY_URL"), "URL of secretary daemon, e.g. https://secretary:5070")
+		cmdExec.Flags().StringVarP(&appID, "app-id", "", os.Getenv("MARATHON_APP_ID"), "Marathon app id")
+		cmdExec.Flags().StringVarP(&appVersion, "app-version", "", os.Getenv("MARATHON_APP_VERSION"), "Marathon app config version")
+		cmdExec.Flags().StringVarP(&taskID, "task-id", "", os.Getenv("MESOS_TASK_ID"), "Mesos task id")
+		rootCmd.AddCommand(cmdExec)
 	}
 
 	// Daemon command


### PR DESCRIPTION
When embedding standalone static binaries in a docker container, it feels nice to use the empty "scratch" docker image as a starting point. However, this fails when also wanting secretary support, since the current workflow requires a shell.

This PR adds the support for `secretary exec -- cmd [args..]` which will decrypt all environment variables and all command line arguments without requiring an embedding shell to do the work.