### PR TITLE
Added a more reliable way to compare app/task versions

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -55,7 +55,11 @@ func decryptRequest(app *MarathonApp, masterKey *[32]byte, serviceEnvelope strin
 	}
 
 	// Validate that appId, appVersion, taskId corresponds to HTTP request params
-	if request.AppID != app.ID || request.AppVersion != app.Version || request.TaskID != app.TaskID {
+	// Parse the timestamps identifying app versions as Time to prevent issues with missing "0" when comparing as str
+	requestAppVersion, _ := strToTimeRFC3339(request.AppVersion)
+	marathonAppVersion, _ := strToTimeRFC3339(app.Version)
+
+	if request.AppID != app.ID || !requestAppVersion.Equal(marathonAppVersion) || request.TaskID != app.TaskID {
 		return nil, errors.New("Given appid,appversion,taskid doesn't correspond to HTTP request params (bug or hacking attempt?)")
 	}
 

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -115,4 +116,12 @@ func httpGet(url string) ([]byte, error) {
 	}
 
 	return httpReadBody(response)
+}
+
+func strToTimeRFC3339(timestr string) (time.Time, error) {
+	rfc3339, err := time.Parse(time.RFC3339, timestr)
+	if err != nil {
+		return rfc3339, fmt.Errorf("Failed to parse time string (%s) due to error (%s)", timestr, err)
+	}
+	return rfc3339, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -70,3 +70,24 @@ func TestStripWhitespace(t *testing.T) {
 	assert.Equal(t, "abc", stripWhitespace(" a b\n c "))
 	assert.Equal(t, "abc", stripWhitespace(" a \r\nb\n c \n"))
 }
+
+func TestStrToTimeRFC3339(t *testing.T) {
+	// Verify there are no errors
+	oneRfc3339, err := strToTimeRFC3339("2017-10-09T11:25:50.03Z")
+	assert.Nil(t, err)
+
+	sameRfc3339, err := strToTimeRFC3339("2017-10-09T11:25:50.030Z")
+	assert.Nil(t, err)
+
+	otherRfc3339, err := strToTimeRFC3339("2017-10-09T11:26:50.03Z")
+	assert.Nil(t, err)
+
+	// Verify there is an error
+	badRfc3339, err := strToTimeRFC3339("bad string")
+	assert.NotNil(t, err)
+
+	// Verify comparison using time.Equal method
+	assert.True(t, oneRfc3339.Equal(sameRfc3339))
+	assert.False(t, otherRfc3339.Equal(sameRfc3339))
+	assert.False(t, badRfc3339.Equal(oneRfc3339))
+}


### PR DESCRIPTION
This commit addresses an issue noted in marathon >= 1.5 when requesting decryption via the /v1/decrypt endpoint:

To proceed with a response, secretary relies in version string comparison (among other things), between the requester POSTed app version against the marathon fetched app/task version;
prior to marathon 1.5 that seemed to work without issues, but since marathon 1.5 we've noticed that, when the timestamp ends in one or more zeros, time strings in app definitions fetched from marathon's api differ with the same app version string as injected into the container environment in the MARATHON_APP_VERSION variable.
In such cases, though `2017-10-09T11:25:50.030Z` and `2017-10-09T11:25:50.03Z` are string representations of the same time, they fail the test when compared as version strings.

To work around this, the places in marathon.go and deamon.go where such comparison takes place have been modified to use a simple function to convert the string into time.Time type and then compare
them as such using the Equal method instead.

The little utility function added in this commit also includes some simple test.
`